### PR TITLE
alias.conf error Only subclasses can override parameters

### DIFF
--- a/manifests/puppetlabs.pp
+++ b/manifests/puppetlabs.pp
@@ -52,7 +52,7 @@ class apache_hardening::puppetlabs(
     unless => "find ${conf_dir} -perm -o+r -type f -o -perm -o+w -type f | wc -l | egrep '^0$'"
   }
 
-  File['alias.conf'] {
+  File <| title == 'alias.conf' |> {
     content => template('apache_hardening/mod/alias.conf.erb'),
     mode   => '0640',
   }


### PR DESCRIPTION
Puppet throws an error "Only subclasses can override parameters". This can be fixed with a resource collector.