### PR TITLE
override files that notify the apache service class

### DIFF
--- a/manifests/puppetlabs.pp
+++ b/manifests/puppetlabs.pp
@@ -38,7 +38,7 @@ class apache_hardening::puppetlabs(
     mode    => '0640',
   }
 
-  File <| notify  == Service['httpd'] or require == Package['httpd'] |>  {
+  File <| notify  == Service['httpd'] or notify == Class['::apache::service'] or require == Package['httpd'] |>  {
     mode  => 0640
   }
 


### PR DESCRIPTION
When turning future parser on, the file permissions override does not work as expected and the runs are not idempotent.

```
Info: Applying configuration version '1435081548'
Notice: /Stage[main]/Apache::Mod::Worker/File[/etc/apache2/mods-available/worker.conf]/mode: mode changed '0640' to '0644'
Info: /Stage[main]/Apache::Mod::Worker/File[/etc/apache2/mods-available/worker.conf]: Scheduling refresh of Class[Apache::Service]
Notice: /Stage[main]/Apache_hardening::Puppetlabs/Exec[chmod -R o-rw /etc/apache2]/returns: executed successfully
Info: /Stage[main]/Apache_hardening::Puppetlabs/Exec[chmod -R o-rw /etc/apache2]: Scheduling refresh of Service[httpd]
Info: Class[Apache::Service]: Scheduling refresh of Service[httpd]
Notice: /Stage[main]/Apache::Service/Service[httpd]: Triggered 'refresh' from 2 events
```

This is because puppetlabs-apache module only notifies the class "Class['apache::service']" and not 
Service['httpd'] directly.

```
file { "${::apache::mod_dir}/itk.conf":
    ensure  => file,
    content => template('apache/mod/itk.conf.erb'),
    require => Exec["mkdir ${::apache::mod_dir}"],
    before  => File[$::apache::mod_dir],
    notify  => Class['apache::service'],
  }
```

This PR addresses this issue by extending the resource collector that does the override to include "Class['apache::service']".